### PR TITLE
Fix indent issue that caused missing MAC addresses

### DIFF
--- a/miners/_backends/btminer.py
+++ b/miners/_backends/btminer.py
@@ -237,7 +237,7 @@ class BTMiner(BaseMiner):
                 logging.info(f"Failed to get mac: {self}")
                 mac = None
 
-            if mac:
-                data.mac = mac
+        if mac:
+            data.mac = mac
 
         return data


### PR DESCRIPTION
When a MAC was already known, it wouldn't be added to the data, since the statement was never reached.